### PR TITLE
fix: fix 500 error when trying to login after creating users with no org

### DIFF
--- a/core/serializers.py
+++ b/core/serializers.py
@@ -29,7 +29,7 @@ class WorkflowSerializer(serializers.ModelSerializer):
             'created_at',
             'updated_at',
         ]
-        
+
 class RunSerializer(serializers.ModelSerializer):
     # If you want the workflow ID in the output:
     workflow_id = serializers.UUIDField(source='workflow.id', read_only=True)
@@ -53,9 +53,13 @@ class OrgTokenObtainPairSerializer(TokenObtainPairSerializer):
         # Get the standard token (refresh + access)
         token = super().get_token(user)
 
-        # Add custom claims
-        # Make sure your CustomUser has an .org relation
-        token['org_id'] = str(user.org.id)       # e.g. UUIDField
-        token['org_name'] = user.org.name        # optional human-readable
+        # Handle cases where user might not have an org (like superusers)
+        if hasattr(user, 'org') and user.org:
+            token['org_id'] = str(user.org.id)
+            token['org_name'] = user.org.name
+        else:
+            # Default values for users without org (like superadmins)
+            token['org_id'] = None
+            token['org_name'] = None
 
         return token


### PR DESCRIPTION
Users/superysers created via manage.py don't have an org by default, we need to first create an org and add them to it from django admin ui to make the login endpoint work, this implements a workaround so the endpoint doesn't completely break when trying to login without having an org assigned to the user